### PR TITLE
fixed the issue that did not allow the namenode to replicate data 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Version 2.0.0 introduces uses wait_for_it script for the cluster startup
 ## Supported Hadoop Versions
 See repository branches for supported hadoop versions
 
+## Update 
+The current version of this repo will fix issues such as:
+* not being able to write files to HDFS using a client library, due to not having enough replications. 
+* allows you to check the status of a specific node via the GUI
+
 ## Quick Start
 
 To deploy an example HDFS cluster, run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   namenode:
     image: bde2020/hadoop-namenode:2.0.0-hadoop3.2.1-java8
     container_name: namenode
+    hostname: namenode
     restart: always
     ports:
       - 9870:9870
@@ -15,39 +16,73 @@ services:
       - CLUSTER_NAME=test
     env_file:
       - ./hadoop.env
+    networks:
+      hadoop_network:
+        aliases:
+          - namenode
 
-  datanode:
+  datanode1:
     image: bde2020/hadoop-datanode:2.0.0-hadoop3.2.1-java8
     container_name: datanode
+    hostname: localhost
     restart: always
+    ports:
+      - 9864:9864
+      - 9866:9866
     volumes:
       - hadoop_datanode:/hadoop/dfs/data
     environment:
       SERVICE_PRECONDITION: "namenode:9870"
     env_file:
       - ./hadoop.env
-  
+    networks:
+      hadoop_network:
+
+  datanode2:
+    image: bde2020/hadoop-datanode:2.0.0-hadoop3.2.1-java8
+    container_name: datanode2
+    hostname: localhost
+    restart: always
+    ports:
+      - 9865:9864
+      - 9867:9866
+    volumes:
+      - hadoop_datanode2:/hadoop/dfs/data
+    environment:
+      SERVICE_PRECONDITION: "namenode:9870"
+    env_file:
+      - ./hadoop.env
+    networks:
+      hadoop_network:
+
   resourcemanager:
     image: bde2020/hadoop-resourcemanager:2.0.0-hadoop3.2.1-java8
     container_name: resourcemanager
+    hostname: resourcemanager
     restart: always
     environment:
       SERVICE_PRECONDITION: "namenode:9000 namenode:9870 datanode:9864"
     env_file:
       - ./hadoop.env
+    networks:
+      hadoop_network:
 
-  nodemanager1:
+  nodemanager:
     image: bde2020/hadoop-nodemanager:2.0.0-hadoop3.2.1-java8
     container_name: nodemanager
+    hostname: nodemanager
     restart: always
     environment:
       SERVICE_PRECONDITION: "namenode:9000 namenode:9870 datanode:9864 resourcemanager:8088"
     env_file:
       - ./hadoop.env
-  
+    networks:
+      hadoop_network:
+
   historyserver:
     image: bde2020/hadoop-historyserver:2.0.0-hadoop3.2.1-java8
     container_name: historyserver
+    hostname: historyserver
     restart: always
     environment:
       SERVICE_PRECONDITION: "namenode:9000 namenode:9870 datanode:9864 resourcemanager:8088"
@@ -55,8 +90,14 @@ services:
       - hadoop_historyserver:/hadoop/yarn/timeline
     env_file:
       - ./hadoop.env
-  
+    networks:
+      hadoop_network:
+
 volumes:
   hadoop_namenode:
   hadoop_datanode:
+  hadoop_datanode2:
   hadoop_historyserver:
+
+networks:
+  hadoop_network:


### PR DESCRIPTION
the error that was fixed was that using the client library [hdfs](github.com/colinmarc/hdfs), hdfs would not write to the datanode because of requiring at least on replication. The fix was to make an extra node. 
the error: 
```
2023-04-06 11:09:31,586 INFO ipc.Server: IPC Server handler 0 on default port 9000, call Call#4 Retry#-1 org.apache.hadoop.hdfs.protocol.ClientProtocol.create from 172.21.0.1:42046
java.io.IOException: Requested replication factor of 0 is less than the required minimum of 1 for /products/<filename>.json, clientName=172.21.0.1
```
other fixes are: 
* explicitly creating a network between de cluster for safe measure
* Adding an alias to the datanode so it can be accessed through the browser.
* downloading files from the GUI actually works as stated below
* uploading files from the GUI works

![image](https://user-images.githubusercontent.com/74105210/230384599-5dbd4534-fa60-47d7-b121-d799edf76a3c.png)
